### PR TITLE
Require CMake version >= 2.8.4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 2.8.4)
 
 project(UseLATEX_DOC NONE)
 

--- a/tests/DefaultTargets/CMakeLists.txt
+++ b/tests/DefaultTargets/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 2.8.4)
 
 project(DefaultTargets NONE)
 

--- a/tests/ImageTypes/CMakeLists.txt
+++ b/tests/ImageTypes/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 2.8.4)
 
 project(ImageTypes NONE)
 

--- a/tests/MultiDotFilename/CMakeLists.txt
+++ b/tests/MultiDotFilename/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 2.8.4)
 
 project(MultiDotFilename NONE)
 

--- a/tests/Subdirectory/CMakeLists.txt
+++ b/tests/Subdirectory/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 2.8.4)
 
 project(Subdirectory NONE)
 


### PR DESCRIPTION
The newest 3.* CMake versions may be missing in some distributions.

The most recent feature required by UseLATEX and its tests is
https://github.com/Kitware/CMake/commit/ced1d5eccd4ae08a6431a5c163be3dd52ca9d59a:
"Skip file-level dependencies on custom targets (#11332)". The commit is
included in the release version 2.8.4.

The following error messages are produced during compilation with
earlier CMake versions:

	[100%] Built target UseLATEX_pdf
	make[2]: *** No rule to make target `UseLATEX_pdf', needed by `UseLATEX_build/CMakeFiles/UseLATEX'.  Stop.

Signed-off-by: Anatoly Borodin <anatoly.borodin@gmail.com>