### PR TITLE
Fix issue with converting synctex paths

### DIFF
--- a/UseLATEX.tex
+++ b/UseLATEX.tex
@@ -2,7 +2,7 @@
 
 \documentclass{article}
 
-\newcommand{\UseLATEXVersion}{2.4.5}
+\newcommand{\UseLATEXVersion}{2.4.7}
 \newcommand{\SANDNumber}{SAND 2008-2743P}
 
 % This wonderful package allows hyphenation in tt fonts and hyphenation of


### PR DESCRIPTION
When using the synctex option with pdflatex, it writes out a file
containing paths to the input files. The problem is that
UseLATEX.cmake copies all the input files, so you get a link to
the copy, not the original. To correct for this UseLATEX.cmake
changed the directories back to the input files, but it only
did so for relative paths. pdflatex writes out absolute paths,
so these were not properly converted. This should fix that issue.

I also noticed that some of the "input" files are actually those
produced by latex programs (e.g. .aux, .bbl). Trying to convert
these paths to the input would cause pointers to files that do
not exist. To try to correct for this I only convert paths of
files of known extensions.